### PR TITLE
Add an entry for the "neural-reconstructor" project.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -23,6 +23,12 @@ module.exports = function(eleventyConfig) {
     });
     eleventyConfig.addFilter("markdown", contents => md.render(contents));
 
+    // Create a "sortedProjects" collection that has all of the projects sorted
+    // alphabetically, by name.
+    eleventyConfig.addCollection("sortedProjects", function(collectionsApi) {
+        return collectionsApi.getFilteredByTag("projects").sort((a, b) => a.data.title.localeCompare(b.data.title));
+    });
+
     // Set 'src' at the source folder and have it output to '_site'.
     return {
         dir: {

--- a/src/_includes/sections/projects.liquid
+++ b/src/_includes/sections/projects.liquid
@@ -2,7 +2,7 @@
     Projects
 </h1>
 
-<div class="grid sm:grid-cols-2 md:grid-cols-3 gap-6 mt-2">
+<div class="grid sm:grid-cols-2 gap-6 mt-2">
     {%- for project in collections.projects reversed -%}
     <article class="flex flex-col">
         <header class="flex flex-row items-end border-b border-b-gray-400">
@@ -12,12 +12,12 @@
 
             <nav class="flex-none">
             {% if project.data.github %}
-                <a href="https://github.com/{{ project.data.github }}" class="md:text-sm">GitHub</a>
+                <a href="https://github.com/{{ project.data.github }}" class="sm:text-sm">GitHub</a>
             {% endif %}
 
             {% if project.data.site %}
                 <span class="inline-block ml-2 md:ml-1 h-3 border-l border-gray-300"></span>
-                <a href="{{ project.data.site }}" class="ml-2 md:text-sm md:ml-1">Site</a>
+                <a href="{{ project.data.site }}" class="ml-2 sm:text-sm md:ml-1">Site</a>
             {% endif %}
             </nav>
         </header>

--- a/src/_includes/sections/projects.liquid
+++ b/src/_includes/sections/projects.liquid
@@ -3,7 +3,7 @@
 </h1>
 
 <div class="grid sm:grid-cols-2 gap-6 mt-2">
-    {%- for project in collections.projects reversed -%}
+    {%- for project in collections.sortedProjects -%}
     <article class="flex flex-col">
         <header class="flex flex-row items-end border-b border-b-gray-400">
             <h2 class="flex-grow">

--- a/src/projects/case-rate.md
+++ b/src/projects/case-rate.md
@@ -5,6 +5,7 @@ github: richengguy/case-rate
 site: https://projects.rzeszutek.ca/case-rate
 description: |
     A simple COVID-19 case rate tracker that can estimate the cases growth
-    factor.  It automatically updates itself every 24 hours.
+    factor.  It automatically updates itself every 24 hours and will be turned
+    off.  Eventually.
 permalink: false
 ---

--- a/src/projects/neural-reconstructor.md
+++ b/src/projects/neural-reconstructor.md
@@ -2,6 +2,9 @@
 title: neural-reconstructor
 date: 2018-11-02
 github: richengguy/neural-reconstructor
-description:
+description: |
+    A small experiment with PyTorch and the MNIST digits database.  There's a
+    small [Jupyter notebook](https://github.com/richengguy/neural-reconstructor/blob/master/reconstruction.ipynb)
+    that explains how it all works.
 permalink: false
 ---

--- a/src/projects/neural-reconstructor.md
+++ b/src/projects/neural-reconstructor.md
@@ -4,7 +4,7 @@ date: 2018-11-02
 github: richengguy/neural-reconstructor
 description: |
     A small experiment with PyTorch and the MNIST digits database.  There's a
-    small [Jupyter notebook](https://github.com/richengguy/neural-reconstructor/blob/master/reconstruction.ipynb)
-    that explains how it all works.
+    [Jupyter notebook](https://github.com/richengguy/neural-reconstructor/blob/master/reconstruction.ipynb)
+    in the repo that explains how it all works.
 permalink: false
 ---

--- a/src/projects/neural-reconstructor.md
+++ b/src/projects/neural-reconstructor.md
@@ -1,0 +1,7 @@
+---
+title: neural-reconstructor
+date: 2018-11-02
+github: richengguy/neural-reconstructor
+description:
+permalink: false
+---

--- a/src/projects/website.md
+++ b/src/projects/website.md
@@ -3,6 +3,6 @@ title: website
 date: 2022-01-03
 github: richengguy/richengguy.github.io
 description: |
-    It's this website.  Go to the GitHub page to see how it's configured.
+    It's this website.  Go to the GitHub repo to see how it's configured.
 permalink: false
 ---


### PR DESCRIPTION
Added a project entry for the [neural-reconstructor](https://github.com/richengguy/neural-reconstructor) project.

Also made a few other adjustments:
* Changed the project layout from 3 to 2 columns.
* Adjusted some of the project descriptions.
* Projects are now sorted by alphabetical order.